### PR TITLE
chore: make llvm-ar and llvm-objcopy commands use version 16 explicitly

### DIFF
--- a/assembly/native/build-ubuntu-static.sh
+++ b/assembly/native/build-ubuntu-static.sh
@@ -81,7 +81,7 @@ create_bundled_archive() {
     if [ -n "$zlib_static_lib" ]; then echo "addlib $zlib_static_lib"; fi
     echo "save"
     echo "end"
-  } | llvm-ar -M
+  } | llvm-ar-16 -M
   ranlib "$output"
 }
 
@@ -117,7 +117,7 @@ mapfile -t tolk_deps < <(query_static_link_archives crypto/fift)
 create_bundled_archive libemulator.a "${emulator_deps[@]}"
 
 rm -f libtolk.a libtolkfiftlib-renamed.a
-/usr/lib/llvm-16/bin/llvm-objcopy \
+llvm-objcopy-16 \
   tolk/libtolkfiftlib.a \
   libtolkfiftlib-renamed.a
 create_bundled_archive libtolk.a libtolkfiftlib-renamed.a "${tolk_deps[@]}"


### PR DESCRIPTION
On some machines, `llvm-ar` does not exist even after running the llvm/clang installation script. It can be fixed with `update-alternatives` on Ubuntu or a symbolic link, but since we demand both LLVM and Clang to be of version 16, let's just explicitly require the proper `llvm-ar-16` binary and be done with it.

Plus, let's not use absolute system paths and instead invoke `llvm-objcopy-16` directly.

cc @i582 @Danil42Russia 